### PR TITLE
grammar. fix typo in abstract

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   </head>
   <body>
     <section id='abstract'>
-      <p>The new scroll events introduced in this document provides web developers a way to listen to the state of the scrolling
+      <p>The new scroll events introduced in this document provide web developers a way to listen to the state of the scrolling
       and when their content is being overscrolled or when the scrolling has finished.
       This information will be useful for the effects such as pull to refresh or history swipe navigations in the web apps.</p>
     </section>


### PR DESCRIPTION
s/provides/provide in abstract, plural "scroll events" should use "provide" as the verb.

from:
The new scroll events introduced in this document provides
to:
The new scroll events introduced in this document provide